### PR TITLE
WordPress 6.9.1 compatibility update

### DIFF
--- a/expire-user-passwords.php
+++ b/expire-user-passwords.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Expire User Passwords
  * Description: Require certain users to change their passwords on a regular basis.
- * Version: 1.3.5
+ * Version: 1.3.6
  * Author: Miller Media
  * Author URI: https://www.millermedia.io
  * License: GPL-2.0
@@ -10,7 +10,7 @@
  * Text Domain: expire-user-passwords
  * Domain Path: /languages
  * Requires PHP: 8.1
- * Tested up to: 6.9
+ * Tested up to: 6.9.1
  *
  * This plugin, like WordPress, is licensed under the GPL.
  * Use it to make something cool, have fun, and share what you've learned with others.
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 }
 
-define( 'EXPIRE_USER_PASSWORDS_VERSION', '1.3.5' );
+define( 'EXPIRE_USER_PASSWORDS_VERSION', '1.3.6' );
 define( 'EXPIRE_USER_PASSWORDS_PLUGIN', plugin_basename( __FILE__ ) );
 define( 'EXPIRE_USER_PASSWORDS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EXPIRE_USER_PASSWORDS_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      fjarrett, millermedianow, millermediadev
 Tags:              admin, login, membership, passwords, profile, security, users
 Requires at least: 4.0
-Tested up to:      6.9
-Stable tag:        1.3.5
+Tested up to:      6.9.1
+Stable tag:        1.3.6
 Requires PHP:      8.1
 License:           GPL-2.0
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -51,6 +51,9 @@ Or use any capability that only your desired role has. This is useful when custo
 3. Users are not permitted to use the same password two times in a row during reset.
 
 == Changelog ==
+
+= 1.3.6 =
+* Tested up to WordPress 6.9.1
 
 = 1.3.5 =
 * Added dismissible review prompt notice after 14 days of usage


### PR DESCRIPTION
Updates plugin to indicate WordPress 6.9.1 compatibility.

**Changes:**
- Bumped plugin version from 1.3.5 to 1.3.6
- Updated 'Tested up to' from 6.9 to 6.9.1
- Added changelog entry for 6.9.1 compatibility

**Testing:**
These are metadata changes only. No code functionality changed.