### PR TITLE
Add POT translation template file

### DIFF
--- a/languages/expire-user-passwords.pot
+++ b/languages/expire-user-passwords.pot
@@ -1,0 +1,101 @@
+# Copyright (C) 2026 Expire User Passwords
+# This file is distributed under the same license as the Expire User Passwords package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Expire User Passwords\n"
+"Report-Msgid-Bugs-To: https://github.com/Miller-Media/expire-passwords/issues\n"
+"POT-Creation-Date: 2026-02-16 13:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Plugin Name of the plugin
+#: expire-user-passwords.php
+#: includes/class-settings.php:33
+#: includes/class-settings.php:34
+#: includes/class-settings.php:74
+#: includes/class-settings.php:240
+msgid "Expire User Passwords"
+msgstr ""
+
+#. Description of the plugin
+#: expire-user-passwords.php
+#: includes/class-settings.php:146
+msgid "Require certain users to change their passwords on a regular basis."
+msgstr ""
+
+#. Author of the plugin
+#: expire-user-passwords.php
+msgid "Miller Media"
+msgstr ""
+
+#. Author URI of the plugin
+#: expire-user-passwords.php
+msgid "https://www.millermedia.io"
+msgstr ""
+
+#: includes/class-list-table.php:67
+msgid "Password Reset"
+msgstr ""
+
+#. translators: X amount of time ago
+#: includes/class-list-table.php:103
+#, php-format
+msgid "%1$s ago"
+msgstr ""
+
+#: includes/class-login-screen.php:115
+msgid "You cannot reuse your old password."
+msgstr ""
+
+#: includes/class-login-screen.php:141
+msgid "Your password must be reset every day."
+msgid_plural "Your password must be reset every %d days."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: includes/class-login-screen.php:161
+msgid "Please enter your username or e-mail below and a password reset link will be sent to you."
+msgstr ""
+
+#: includes/class-settings.php:114
+msgid "Require password reset every"
+msgstr ""
+
+#: includes/class-settings.php:122
+msgid "For users in these roles"
+msgstr ""
+
+#: includes/class-settings.php:129
+msgid "Reset via email"
+msgstr ""
+
+#: includes/class-settings.php:165
+msgid "days"
+msgstr ""
+
+#: includes/class-settings.php:210
+msgid "Send an email with the password reset link."
+msgstr ""
+
+#: includes/class-settings.php:215
+msgid "Reset password directly on the login screen."
+msgstr ""
+
+#: includes/class-settings.php:239
+#, php-format
+msgid "Do you like the %1$s plugin? Please consider %2$s on %3$s"
+msgstr ""
+
+#: includes/class-settings.php:244
+msgid "leaving a &#9733;&#9733;&#9733;&#9733;&#9733; review"
+msgstr ""
+


### PR DESCRIPTION
Adds `languages/expire-user-passwords.pot` — the translation template file that enables the WordPress.org translation community to contribute translations via [translate.wordpress.org](https://translate.wordpress.org/).

The POT file contains all translatable strings extracted from the plugin with empty `msgstr` values, serving as the base template for all language translations.